### PR TITLE
parameterize the lxd alias

### DIFF
--- a/tasks/lxd.yml
+++ b/tasks/lxd.yml
@@ -14,7 +14,7 @@
       mode: pull
       server: https://images.linuxcontainers.org
       protocol: lxd
-      alias: "ubuntu/xenial/amd64"
+      alias: '{{ hostvars[item].get("lxd_alias", "ubuntu/xenial/amd64") }}'
     profiles: ['default']
     wait_for_ipv4_addresses: true
   when: item.split('.')[-1] == 'lxd'


### PR DESCRIPTION
I ran the test script with:
`ansible-playbook test.yml -e "test_lxc=false"`

and also by commenting out the sudo/become part, as LXD does not need sudo. 

Do you think we should modify it so that the lxd components do not use `become`, to make it more proper?
