### PR TITLE
Bugfix: support having group names equal to host names

### DIFF
--- a/tasks/lxd.yml
+++ b/tasks/lxd.yml
@@ -22,38 +22,36 @@
 
 - name: Add lxd host with lxd connection to setup python & ssh
   add_host:
-    name: '{{ item.split(".")[0] }}'
+    name: 'novafloss.boot-lxd-{{ item.split(".")[0] }}'
+    ansible_ssh_host: '{{ item.split(".")[0] }}'
     ansible_connection: lxd
-  when: item.split('.')[-1] == 'lxd'
+    group: 'novafloss.boot-lxd'
+  when: item.endswith('.lxd')
   with_items: '{{ groups["all"] }}'
 
 - name: Refresh packages
   raw: if hash apt-get; then apt-get update; elif hash apk; then apk update; fi
   become: no
-  delegate_to: '{{ item.split(".")[0] }}'
-  when: item.split('.')[-1] == 'lxd'
-  with_items: '{{ groups["all"] }}'
+  delegate_to: '{{ item }}'
+  with_items: '{{ groups["novafloss.boot-lxd"] }}'
 
 - name: Install sshd
   raw: if ! hash sshd; then if hash apt-get; then apt-get install -y openssh-server; elif hash apk; then apk add openssh; fi; fi
   become: no
-  delegate_to: '{{ item.split(".")[0] }}'
-  when: item.split('.')[-1] == 'lxd'
-  with_items: '{{ groups["all"] }}'
+  delegate_to: '{{ item }}'
+  with_items: '{{ groups["novafloss.boot-lxd"] }}'
 
 - name: Install python in container
   raw: if ! hash python2; then if hash apt-get; then apt-get install -y python; elif hash apk; then apk add python; fi; fi
   become: no
-  delegate_to: '{{ item.split(".")[0] }}'
-  when: item.split('.')[-1] == 'lxd'
-  with_items: '{{ groups["all"] }}'
+  delegate_to: '{{ item }}'
+  with_items: '{{ groups["novafloss.boot-lxd"] }}'
 
 - name: Gather facts
   setup:
   become: no
-  delegate_to: '{{ item.split(".")[0] }}'
-  when: item.split('.')[-1] == 'lxd'
-  with_items: '{{ groups["all"] }}'
+  delegate_to: '{{ item }}'
+  with_items: '{{ groups["novafloss.boot-lxd"] }}'
   register: setup
 
 - name: Start and enable sshd
@@ -62,9 +60,8 @@
     state: started
     enabled: yes
   become: no
-  delegate_to: '{{ item["item"].split(".")[0] }}'
-  when: item['item'].split('.')[-1] == 'lxd' and item['ansible_facts']['ansible_os_family'] == 'Alpine'
-  with_items: '{{ setup.results }}'
+  delegate_to: '{{ item }}'
+  with_items: '{{ groups["novafloss.boot-lxd"] }}'
 
 - name: Add your ssh key to the container
   authorized_key:
@@ -72,21 +69,22 @@
     path: /root/.ssh/authorized_keys
     user: root
   become: no
-  delegate_to: '{{ item.split(".")[0] }}'
-  when: item.split('.')[-1] == 'lxd'
-  with_items: '{{ groups["all"] }}'
+  delegate_to: '{{ item }}'
+  with_items: '{{ groups["novafloss.boot-lxd"] }}'
 
 - name: Install sudo in container
   raw: if hash apt-get; then apt-get install -y sudo; elif hash apk; then apk add sudo; fi
   become: no
-  delegate_to: '{{ item.split(".")[0] }}'
-  when: item.split('.')[-1] == 'lxd'
-  with_items: '{{ groups["all"] }}'
+  delegate_to: '{{ item }}'
+  with_items: '{{ groups["novafloss.boot-lxd"] }}'
+
+- debug: msg={{ item.replace("novafloss.boot-lxd-", "") }}
+  with_items: '{{ groups["novafloss.boot-lxd"] }}'
 
 - name: Wait for containers to start sshd
   wait_for:
     host: '{{ item }}'
     port: 22
     search_regex: OpenSSH
-  when: item.split('.')[-1] == 'lxd'
+  when: item.endswith('lxd')
   with_items: '{{ groups["all"] }}'

--- a/test.yml
+++ b/test.yml
@@ -8,15 +8,15 @@
     test_lxc: true
     test_lxd: true
   pre_tasks:
-  - add_host: name=testboot.lxc groups=testgroup
+  - add_host: name=testboot.lxc groups=testboot
     when: test_lxc
-  - add_host: name=testboot.lxd groups=testgroup
+  - add_host: name=testboot.lxd groups=testboot
     when: test_lxd
-  - add_host: name=testbootalpine.lxd groups=testgroup lxd_alias=alpine/3.4/amd64
+  - add_host: name=testbootalpine.lxd groups=testboot lxd_alias=alpine/3.4/amd64
     when: test_lxd
   roles:
   - .
 
-- hosts: testgroup
+- hosts: testboot
   tasks:
   - shell: uname -a


### PR DESCRIPTION
The problem is that delegate_to is evaluated even for skipped tasks.
Without patching tasks/lxd.yml, the new test.yml in this commit would
fail with:

```
Traceback (most recent call last):
  File "/home/jpic/env/src/ansible/bin/ansible-playbook", line 97, in <module>
    exit_code = cli.run()
  File "/home/jpic/env/src/ansible/lib/ansible/cli/playbook.py", line 154, in run
    results = pbex.run()
  File "/home/jpic/env/src/ansible/lib/ansible/executor/playbook_executor.py", line 144, in run
    self._inventory.restrict_to_hosts(batch)
  File "/home/jpic/env/src/ansible/lib/ansible/inventory/__init__.py", line 640, in restrict_to_hosts
    self._restriction = [ h.name for h in restriction ]
AttributeError: 'NoneType' object has no attribute 'name'
```

https://github.com/ansible/ansible/issues/16972
