### PR TITLE
Fix idempotent task "Install python in container"

### DIFF
--- a/tasks/lxc.yml
+++ b/tasks/lxc.yml
@@ -29,10 +29,14 @@
   with_items: '{{ groups["all"] }}'
 
 - name: Install python in container
-  raw: if ! hash python2; then apt-get update -y && apt-get install -y python; fi
+  raw: >
+    if ! hash python2;
+      then apt-get update -y && apt-get install -y python;
+    fi
   become: no
   delegate_to: '{{ item }}'
   when: item.split('.')[-1] == 'lxc'
+  changed_when: false
   with_items: '{{ groups["all"] }}'
 
 - name: Install sudo in container


### PR DESCRIPTION
Little contribution to ansible-role-boot to have more idempotent tasks.
When run the roles multiple times, it should be idempotent. The task
Install python in container is not idempotent.
We can use the "changed_when" keyword to make it idempotent from ansible
point of view.