### PR TITLE
allows custom LXC container config from inventory

### DIFF
--- a/tasks/lxc.yml
+++ b/tasks/lxc.yml
@@ -6,6 +6,7 @@
     template: '{{ hostvars[item].get("lxc_template", "debian") }}'
     state: started
     template_options: '{{ hostvars[item].get("lxc_template_options", "") }}'
+    container_config: '{{ hostvars[item].get("lxc_container_config", "") }}'
     lxc_path: '{{ hostvars[item].get("lxc_path", lxc_path) }}'
     container_log: true
     container_log_level: DEBUG


### PR DESCRIPTION
The `lxc_container` module has a `container_config` option that allows to pass options such as `lxc.mount.entry`.

In the current configuration (at least as per c7f522f), the developers have to mount the src folder by themselves.

This PR will allow to update Ansible plabooks so that mounts and other options can be integrated from within the inventories.

ping @mgu @aRkadeFR 